### PR TITLE
Fix initial startup of jobs

### DIFF
--- a/seguro/commands/scheduler/scheduler.py
+++ b/seguro/commands/scheduler/scheduler.py
@@ -86,9 +86,7 @@ class Scheduler(compose.Composer):
         self.logger.info(f"Added new job: {name}")
 
         if triggers := new_job.job_spec.triggers:
-            for trigger in triggers:
-                if not isinstance(trigger, model.EventTrigger):
-                    continue
+            for trigger in triggers.values():
 
                 if trigger.type != model.EventTriggerType.STARTUP:
                     continue


### PR DESCRIPTION
Fixed initial startup of `EventTriggerType.STARTUP` jobs by iterating over the values instead of the keys of the `dict: triggers`.

I still think we don't need the redundant check, as all trigger types have a `type` field... What do you think @stv0g ?