### PR TITLE
Force LF file endings for all shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Felix Wege, EONERC-ACS, RWTH Aachen University
+# SPDX-License-Identifier: Apache-2.0
+
 # ensure LF line endings for all shell scripts
 *.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# ensure LF line endings for all shell scripts
+*.sh text eol=lf


### PR DESCRIPTION
Forcing LF file endings for all shell scripts fixes the issue where cloning the repository on Windows led to errors in the setup-related scripts when starting the platform inside the devcontainer.