### PR TITLE
Improve demo data to simplify development of services

### DIFF
--- a/seguro/commands/fiware_connector/main.py
+++ b/seguro/commands/fiware_connector/main.py
@@ -72,6 +72,13 @@ def post_sample(
     )
 
 
+def convert_complex(complexVal: complex) -> dict:
+    return {
+        "re": complexVal.real,
+        "im": complexVal.imag,
+    }
+
+
 def main() -> int:
 
     parser = argparse.ArgumentParser()
@@ -114,25 +121,25 @@ def main() -> int:
             samples[0].ts_origin,
             json.dumps(  # Voltage
                 {
-                    "L1": str(samples[-1].data[0]),
-                    "L2": str(samples[-1].data[1]),
-                    "L3": str(samples[-1].data[2]),
+                    "L1": convert_complex(samples[-1].data[0]),
+                    "L2": convert_complex(samples[-1].data[1]),
+                    "L3": convert_complex(samples[-1].data[2]),
                 },
                 separators=(",", ":"),
             ),
             json.dumps(  # Current
                 {
-                    "L1": str(samples[-1].data[3]),
-                    "L2": str(samples[-1].data[4]),
-                    "L3": str(samples[-1].data[5]),
+                    "L1": convert_complex(samples[-1].data[3]),
+                    "L2": convert_complex(samples[-1].data[4]),
+                    "L3": convert_complex(samples[-1].data[5]),
                 },
                 separators=(",", ":"),
             ),
             json.dumps(  # Power
                 {
-                    "L1": str(samples[-1].data[6]),
-                    "L2": str(samples[-1].data[7]),
-                    "L3": str(samples[-1].data[8]),
+                    "L1": convert_complex(samples[-1].data[6]),
+                    "L2": convert_complex(samples[-1].data[7]),
+                    "L3": convert_complex(samples[-1].data[8]),
                 },
                 separators=(",", ":"),
             ),

--- a/store/config/jobs/demo-data.yaml
+++ b/store/config/jobs/demo-data.yaml
@@ -7,8 +7,8 @@ container:
 
   environment:
     RATE: "10.0"
-    VALUES: "6"
     BLOCK_INTERVAL: "1m"
-    TOPIC: data/measurements/mp1
+    SAMPLE_TYPE: "measurement"
+    TOPIC: data/measurements/demo-data
 
   command: ["demo-data"]


### PR DESCRIPTION
To simplify the development of platform services (and especially the planned business case logics), the `demo-data` service should be improved to provide demo data which resembles actual data that is expected to be sent by the measurement gateways. This allows to implement parsing/processing scripts without the need of deploying the gateway physically or emulated.

Changes include:
- Add `--sample-type` option which allows switching between `simple` (i.e., sending defined number of random floats) and `measurement`, which generates samples resembling actual gateway samples
- Change default topic to `/data/measurements/demo-data`
- Correctly set timestamps in sent samples
- Change job configuration of `demo-data` job to send measurement samples

