### PR TITLE
fix: block interval in days not seconds

### DIFF
--- a/seguro/commands/demo_data/main.py
+++ b/seguro/commands/demo_data/main.py
@@ -76,7 +76,7 @@ def main() -> int:
     pb = Protobuf()
 
     last_block = datetime.now()
-    block_interval = timedelta(args.block_interval)
+    block_interval = timedelta(seconds = args.block_interval)
 
     while True:
 


### PR DESCRIPTION
In the `demo-data` service there was an issue with the `block_interval`. Without keyword the first argument is in days while the parser return number in seconds, turning `1m` into a 60 day `block_interval`.